### PR TITLE
chore(github): configure to run ci only on pr to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request makes a small change to the CI workflow configuration. The change removes the workflow trigger for pushes to the `main` branch, so CI will now only run on pull requests targeting `main`.