### PR TITLE
chore(github): configure to run security check only on pr to main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,6 @@ name: Security Checks
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
   schedule:
     # Run weekly on Mondays at 9am UTC
     - cron: '0 9 * * 1'


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for security checks, focusing on when the workflow is triggered.

* Workflow trigger update:
  - Removed the `push` trigger for the `main` branch in `.github/workflows/security.yml`, so security checks will now only run on pull requests and on a weekly schedule.