### PR TITLE
fix(valentine): fix mobile responsiveness of valentine page

### DIFF
--- a/app/valentine/components/central-image.tsx
+++ b/app/valentine/components/central-image.tsx
@@ -49,8 +49,8 @@ function getObjectPosition(
 
 function getFrameClassName(isPortrait: boolean | null): string {
   return isPortrait
-    ? "h-[260px] sm:h-[320px] md:h-[520px] md:w-[520px]"
-    : "h-[200px] sm:h-[250px] md:h-[400px] md:w-[700px]";
+    ? "w-full max-w-[92vw] aspect-[4/5] sm:aspect-[3/4] md:aspect-auto md:h-[520px] md:w-[520px]"
+    : "w-full max-w-[92vw] aspect-[3/2] sm:aspect-[16/10] md:aspect-auto md:h-[400px] md:w-[700px]";
 }
 
 export function CentralImage({ memory, currentIndex, onNext }: CentralImageProps) {


### PR DESCRIPTION
This pull request updates the styling logic for the image frame in the `CentralImage` component. The main change is a shift from fixed height and width values to using responsive width and aspect ratio classes, which should improve how images scale across different screen sizes.

Styling and responsiveness improvements:

* [`app/valentine/components/central-image.tsx`](diffhunk://#diff-c26d64f82ddf4f9e495fb632b9c902693290f7acf7c5acd81d3f6e30db6d86b4L52-R53): Updated the `getFrameClassName` function to use responsive `w-full`, `max-w-[92vw]`, and `aspect-*` classes instead of fixed heights and widths, enhancing image frame adaptability for both portrait and landscape orientations.